### PR TITLE
MSFT_xAdcsWebEnrollment - Updated to IsSingleInstance model - Fixes #7

### DIFF
--- a/DSCResources/MSFT_xAdcsOnlineResponder/MSFT_xAdcsOnlineResponder.psm1
+++ b/DSCResources/MSFT_xAdcsOnlineResponder/MSFT_xAdcsOnlineResponder.psm1
@@ -9,23 +9,25 @@ Function Get-TargetResource
     param(
         [parameter(Mandatory = $true)]
         [ValidateSet('Yes')]
-        [String]
-        $IsSingleInstance, 
+        [String] $IsSingleInstance, 
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet('Present','Absent')]
-        [string]$Ensure = 'Present',
+        [string] $Ensure = 'Present',
 
-        [Parameter(Mandatory)]
-        [pscredential]$Credential
+        [Parameter(Mandatory = $true)]
+        [pscredential] $Credential
     )
 
     $ADCSParams = @{
         IsSingleInstance = $IsSingleInstance
         Credential = $Credential
-        Ensure = $Ensure }
+        Ensure = $Ensure
+    }
 
-    $ADCSParams += @{ StateOK = Test-TargetResource @ADCSParams }
+    $ADCSParams += @{
+        StateOK = Test-TargetResource @ADCSParams
+    }
     Return $ADCSParams
 }
 #endregion
@@ -37,23 +39,31 @@ Function Set-TargetResource
     param(
         [parameter(Mandatory = $true)]
         [ValidateSet('Yes')]
-        [String]
-        $IsSingleInstance, 
+        [String] $IsSingleInstance, 
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet('Present','Absent')]
-        [string]$Ensure = 'Present',
+        [string] $Ensure = 'Present',
 
-        [Parameter(Mandatory)]
-        [pscredential]$Credential
+        [Parameter(Mandatory = $true)]
+        [pscredential] $Credential
     )
 
-    $ADCSParams = @{ Credential = $Credential }
+    $ADCSParams = @{
+        Credential = $Credential
+    }
 
-    switch ($Ensure) {
-        'Present' {(Install-AdcsOnlineResponder @ADCSParams -Force).ErrorString}
-        'Absent' {(Uninstall-AdcsOnlineResponder -Force).ErrorString}
+    switch ($Ensure)
+    {
+        'Present'
+        {
+            (Install-AdcsOnlineResponder @ADCSParams -Force).ErrorString
         }
+        'Absent'
+        {
+            (Uninstall-AdcsOnlineResponder -Force).ErrorString
+        }
+    } # Switch
 }
 #endregion
 
@@ -65,33 +75,50 @@ Function Test-TargetResource
     param(
         [parameter(Mandatory = $true)]
         [ValidateSet('Yes')]
-        [String]
-        $IsSingleInstance, 
+        [String] $IsSingleInstance,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet('Present','Absent')]
-        [string]$Ensure = 'Present',
+        [string] $Ensure = 'Present',
 
-        [Parameter(Mandatory)]
-        [pscredential]$Credential
+        [Parameter(Mandatory = $true)]
+        [pscredential] $Credential
     )
 
-    $ADCSParams = @{ Credential = $Credential }
+    $ADCSParams = @{
+        Credential = $Credential
+    }
 
-    try{
+    try
+    {
         $null = Install-AdcsOnlineResponder @ADCSParams -WhatIf
-        Switch ($Ensure) {
-            'Present' {return $false}
-            'Absent' {return $true}
+        Switch ($Ensure)
+        {
+            'Present'
+            {
+                return $false
             }
-    }
-    catch{
-        Write-verbose $_
-        Switch ($Ensure) {
-            'Present' {return $true}
-            'Absent' {return $false}
+            'Absent'
+            {
+                return $true
             }
+        } # Switch
     }
+    catch
+    {
+        Write-verbose -Verbose $_
+        Switch ($Ensure)
+        {
+            'Present'
+            {
+                return $true
+            }
+            'Absent'
+            {
+                return $false
+            }
+        } # Switch
+    } # try
 }
 #endregion
 

--- a/DSCResources/MSFT_xAdcsWebEnrollment/MSFT_xAdcsWebEnrollment.psm1
+++ b/DSCResources/MSFT_xAdcsWebEnrollment/MSFT_xAdcsWebEnrollment.psm1
@@ -4,21 +4,36 @@ Function Get-TargetResource
     [OutputType([System.Collections.Hashtable])]
     [CmdletBinding()]
     param(
-    [ValidateSet('Present','Absent')]
-    [string]$Ensure = 'Present',
-    [string]$CAConfig,
-    [Parameter(Mandatory)]
-    [pscredential]$Credential,
-    [Parameter(Mandatory)]
-    [string]$Name
+        [parameter(Mandatory = $true)]
+        [ValidateSet('Yes')]
+        [String] $IsSingleInstance,
+
+        [ValidateSet('Present','Absent')]
+        [string] $Ensure = 'Present',
+
+        [string] $CAConfig,
+
+        [Parameter(Mandatory = $true)]
+        [pscredential] $Credential
     )
 
-    $ADCSParams = if (!$CAConfig) {@{Credential = $Credential}} else  {@{CAConfig = $CAConfig; Credential = $Credential}}
-
-    return @{Ensure = $Ensure
+    $ADCSParams = @{
+        IsSingleInstance = $IsSingleInstance
         Credential = $Credential
+        Ensure = $Ensure        
+    }
+
+    if ($CAConfig)
+    {
+        $ADCSParams += @{
+            CAConfig = $CAConfig
+        }
+    } # if
+
+    $ADCSParams += @{
         IsCAWeb = Test-TargetResource @ADCSParams
     }
+    return $ADCSParams
 }
 # Get-TargetResource -Name 'Test' -Credential (Get-Credential)
 # Expected Outcome: Return a table of appropriate values.
@@ -29,21 +44,44 @@ Function Set-TargetResource
 {
     [CmdletBinding()]
     param(
-    [ValidateSet('Present','Absent')]
-    [string]$Ensure = 'Present',
-    [string]$CAConfig,
-    [Parameter(Mandatory)]
-    [pscredential]$Credential,
-    [Parameter(Mandatory)]
-    [string]$Name
+        [parameter(Mandatory = $true)]
+        [ValidateSet('Yes')]
+        [String] $IsSingleInstance,
+
+        [ValidateSet('Present','Absent')]
+        [string] $Ensure = 'Present',
+
+        [string] $CAConfig,
+
+        [Parameter(Mandatory = $true)]
+        [pscredential] $Credential
     )
 
-    $ADCSParams = if (!$CAConfig) {@{Credential = $Credential}} else  {@{CAConfig = $CAConfig; Credential = $Credential}}
-
-    switch ($Ensure) {
-        'Present' {(Install-AdcsWebEnrollment @ADCSParams -Force).ErrorString}
-        'Absent' {(Uninstall-AdcsWebEnrollment -Force).ErrorString}
+    if (-not $CAConfig)
+    {
+        $ADCSParams = @{
+            Credential = $Credential
         }
+    }
+    else
+    {
+        $ADCSParams = @{
+            CAConfig = $CAConfig
+            Credential = $Credential
+        }
+    } # if
+
+    switch ($Ensure)
+    {
+        'Present'
+        {
+            (Install-AdcsWebEnrollment @ADCSParams -Force).ErrorString
+        }
+        'Absent'
+        {
+            (Uninstall-AdcsWebEnrollment -Force).ErrorString
+        }
+    } # switch
 }
 # Set-TargetResource -Name 'Test' -Credential (Get-Credential)
 # Expected Outcome: Setup Certificate Services Web Enrollment on this node.
@@ -55,31 +93,63 @@ Function Test-TargetResource
     [OutputType([System.Boolean])]
     [CmdletBinding()]
     param(
-    [ValidateSet('Present','Absent')]
-    [string]$Ensure = 'Present',
-    [string]$CAConfig,
-    [Parameter(Mandatory)]
-    [pscredential]$Credential,
-    [Parameter(Mandatory)]
-    [string]$Name
+        [parameter(Mandatory = $true)]
+        [ValidateSet('Yes')]
+        [String] $IsSingleInstance,
+
+        [ValidateSet('Present','Absent')]
+        [string] $Ensure = 'Present',
+
+        [string] $CAConfig,
+
+        [Parameter(Mandatory = $true)]
+        [pscredential] $Credential
     )
 
-    $ADCSParams = if (!$CAConfig) {@{Credential = $Credential}} else  {@{CAConfig = $CAConfig; Credential = $Credential}}
+    if (-not $CAConfig)
+    {
+        $ADCSParams = @{
+            Credential = $Credential
+        }
+    }
+    else
+    {
+        $ADCSParams = @{
+            CAConfig = $CAConfig
+            Credential = $Credential
+        }
+    } # if
 
-    try{
-        $test = Install-AdcsWebEnrollment @ADCSParams -WhatIf
-        Switch ($Ensure) {
-            'Present' {return $false}
-            'Absent' {return $true}
+    try
+    {
+        $null = Install-AdcsWebEnrollment @ADCSParams -WhatIf
+        Switch ($Ensure)
+        {
+            'Present'
+            {
+                return $false
             }
+            'Absent'
+            {
+                return $true
+            }
+        } # switch
     }
-    catch{
+    catch
+    {
         Write-verbose $_
-        Switch ($Ensure) {
-            'Present' {return $true}
-            'Absent' {return $false}
+        Switch ($Ensure)
+        {
+            'Present'
+            {
+                return $true
             }
-    }
+            'Absent'
+            {
+                return $false
+            }
+        } # switch
+    } # try
 }
 # Test-TargetResource -Name 'Test' -Credential (Get-Credential)
 # Expected Outcome: Returns a boolean indicating whether Certificate Services Web Enrollment is installed on this node.

--- a/DSCResources/MSFT_xAdcsWebEnrollment/MSFT_xAdcsWebEnrollment.schema.mof
+++ b/DSCResources/MSFT_xAdcsWebEnrollment/MSFT_xAdcsWebEnrollment.schema.mof
@@ -1,4 +1,4 @@
-[ClassVersion("0.2.0.0"), FriendlyName("xAdcsWebEnrollment")]
+[ClassVersion("0.1.0.0"), FriendlyName("xAdcsWebEnrollment")]
 class MSFT_xAdcsWebEnrollment : OMI_BaseResource
 {
     [Key, Description("Specifies the resource is a single instance, the value must be 'Yes'"), ValueMap{"Yes"}, Values{"Yes"}] String IsSingleInstance;

--- a/DSCResources/MSFT_xAdcsWebEnrollment/MSFT_xAdcsWebEnrollment.schema.mof
+++ b/DSCResources/MSFT_xAdcsWebEnrollment/MSFT_xAdcsWebEnrollment.schema.mof
@@ -1,9 +1,9 @@
-[ClassVersion("0.1.0.0"), FriendlyName("xAdcsWebEnrollment")]
+[ClassVersion("0.2.0.0"), FriendlyName("xAdcsWebEnrollment")]
 class MSFT_xAdcsWebEnrollment : OMI_BaseResource
 {
+    [Key, Description("Specifies the resource is a single instance, the value must be 'Yes'"), ValueMap{"Yes"}, Values{"Yes"}] String IsSingleInstance;
     [Write, Description("CAConfig parameter string. Do not specify this if there is a local CA installed.")] String CAConfig;
     [Required, Description("If the Web Enrollment service is configured to use Standalone certification authority, then an account that is a member of the local Administrators on the CA is required. If the Web Enrollment service is configured to use an Enterprise CA, then an account that is a member of Domain Admins is required."), EmbeddedInstance("MSFT_Credential")] String Credential;
     [Write, Description("Specifies whether the Web Enrollment feature should be installed or uninstalled."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
-    [Key] String Name;
 };
 

--- a/Examples/Config-SetupActiveDirectory.ps1
+++ b/Examples/Config-SetupActiveDirectory.ps1
@@ -163,13 +163,16 @@ if ((test-path C:\Windows\temp\FirstDC.txt) -eq $True)
 
             xADCSWebEnrollment CertSrv
             {
+                IsSingleInstance = 'Yes'
                 Ensure = 'Absent'
-                Name = 'CertSrv'
                 Credential = $Node.Credential
                 DependsOn = '[xADCSCertificationAuthority]ADCS'
             }
             
-            LocalConfigurationManager            {                CertificateId = $node.Thumbprint                ConfigurationMode = 'ApplyandAutoCorrect'
+            LocalConfigurationManager
+            {
+                CertificateId = $node.Thumbprint
+                ConfigurationMode = 'ApplyandAutoCorrect'
                 RebootNodeIfNeeded = 'True'
             }
         }
@@ -230,7 +233,10 @@ if ((test-path C:\Windows\temp\FirstDC.txt) -eq $False)
                 DependsOn = '[xDisk]DataDisk', '[WindowsFeature]AD-Domain-Services', '[xWaitforADDomain]WaitforDomain'
             }
 
-            LocalConfigurationManager            {                CertificateId = $node.Thumbprint                ConfigurationMode = 'ApplyandAutoCorrect'
+            LocalConfigurationManager
+            {
+                CertificateId = $node.Thumbprint
+                ConfigurationMode = 'ApplyandAutoCorrect'
                 RebootNodeIfNeeded = 'True'
             }
         }
@@ -240,7 +246,11 @@ DomainController -ConfigurationData $configData -OutputPath $PSScriptRoot
 
 }
 
-#endregion#region Apply MOFwinrm quickconfig -quiet
+#endregion
+
+#region Apply MOF
+
+winrm quickconfig -quiet
 
 Set-DscLocalConfigurationManager -ComputerName $env:COMPUTERNAME -Path $PSScriptRoot -Verbose
 Start-DscConfiguration -ComputerName $env:COMPUTERNAME -Path $PSScriptRoot -Force -Verbose -Wait

--- a/Examples/Config-SetupActiveDirectory.ps1
+++ b/Examples/Config-SetupActiveDirectory.ps1
@@ -250,7 +250,7 @@ DomainController -ConfigurationData $configData -OutputPath $PSScriptRoot
 
 #region Apply MOF
 
-winrm quickconfig -quiet
+Set-WSManQuickConfig -Force > $null
 
 Set-DscLocalConfigurationManager -ComputerName $env:COMPUTERNAME -Path $PSScriptRoot -Verbose
 Start-DscConfiguration -ComputerName $env:COMPUTERNAME -Path $PSScriptRoot -Force -Verbose -Wait

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ For more information on ADCS Online Responders, see [this article on TechNet](ht
 * MSFT_xAdcsOnlineResponder: Update Unit tests to use v1.0 Test Template.
                              Unit tests can be run without AD CS installed.
                              Update to meet Style Guidelines and ensure consistency.
+* Usage of WinRm.exe replaced in Config-SetupActiveDirectory.ps1 example file with Set-WSManQuickConfig cmdlet. 
 
 ### 0.2.0.0
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 # xAdcsDeployment
 
 The **xAdcsDeployment** DSC resources have been specifically tested as a method to populate a Certificate Services server role on Windows Server 2012 R2 after the Certificate Services role and the Web Enrollment feature have been enabled.
-Active Directory Certificate Services (AD CS) is used to create certification authorities and related role services that allow you to issue and manage certificates used in a variety of applications. 
+Active Directory Certificate Services (AD CS) is used to create certification authorities and related role services that allow you to issue and manage certificates used in a variety of applications.
 
 ## Scenario
 
 Certificates are widely used to establish trust relationships between computers.
-This DSC resource can be used to address some of the most common scenarios including the need for a Stand-Alone Certificate Authority or an Active Directory Trusted Root Certificate Authority and the Certificate Services website for users to submit and complete certificate requests. 
+This DSC resource can be used to address some of the most common scenarios including the need for a Stand-Alone Certificate Authority or an Active Directory Trusted Root Certificate Authority and the Certificate Services website for users to submit and complete certificate requests.
 
 In a specific example, when building out a web server workload such as an internal website that provides confidential information to be accessed from computers that are members of an Active Directory domain, AD CS can provide a source for the SSL certificats that will automatically be trusted.
 
@@ -181,10 +181,17 @@ In a specific example, when building out a web server workload such as an intern
 
 ### xAdcsWebEnrollment
 
+`IsSingleInstance = <String>`
+  Specifies the resource is a single instance, the value must be 'Yes'
+
+| Required | Key?  | Default value |
+| -------- | ----- | ------------- |
+| True     | True  | none          |
+
 `CAConfig = <String>`
   CAConfig parameter string. 
   Do not specify this if there is a local CA installed. 
-  
+
 | Required | Key?  | Default value |
 | -------- | ----- | ------------- |
 | False    | False | none          |
@@ -196,20 +203,13 @@ In a specific example, when building out a web server workload such as an intern
 | Required | Key?  | Default value |
 | -------- | ----- | ------------- |
 | True     | False | none          |
-  
+
 `Ensure = <String> { Present | Absent }`
   Specifies whether the Web Enrollment feature should be installed or uninstalled. 
-  
+
 | Required | Key?  | Default value |
 | -------- | ----- | ------------- |
 | False    | False | Present       |
-  
-`Name = <String>`
-  A name that provides a unique identifier for the resource instance.
-  
-| Required | Key?  | Default value |
-| -------- | ----- | ------------- |
-| True     | True  | none          |
 
 ### xAdcsOnlineResponder
 
@@ -221,7 +221,7 @@ For more information on ADCS Online Responders, see [this article on TechNet](ht
 
 `IsSingleInstance = <String>`
   Specifies the resource is a single instance, the value must be 'Yes'
-  
+
 | Required | Key?  | Default value |
 | -------- | ----- | ------------- |
 | True     | True  | none          |
@@ -233,14 +233,13 @@ For more information on ADCS Online Responders, see [this article on TechNet](ht
 | Required | Key?  | Default value |
 | -------- | ----- | ------------- |
 | True     | False | none          |
-  
+
 `Ensure = <String> { Present | Absent }`
-  Specifies whether the Online Responder feature should be installed or uninstalled. 
-  
+  Specifies whether the Online Responder feature should be installed or uninstalled.
+
 | Required | Key?  | Default value |
 | -------- | ----- | ------------- |
 | True     | False | Present       |
-
 
 ## Versions
 
@@ -249,19 +248,25 @@ For more information on ADCS Online Responders, see [this article on TechNet](ht
 * Moved Examples folder into root.
 * Removed legacy xCertificateServices folder.
 * Prevented Unit tests from Violating PSSA rules.
+* MSFT_xAdcsWebEnrollment: Created unit tests based on v1.0 Test Template.
+                           Update to meet Style Guidelines and ensure consistency.
+                           Updated to IsSingleInstance model. **Breaking change**
+* MSFT_xAdcsOnlineResponder: Update Unit tests to use v1.0 Test Template.
+                             Unit tests can be run without AD CS installed.
+                             Update to meet Style Guidelines and ensure consistency.
 
 ### 0.2.0.0
 
 * Added the following resources:
     * MSFT_xADCSOnlineResponder resource to install the Online Responder service.
 *   Correction to xAdcsCertificationAuthority property title in Readme.md.
-*   Addition of .gitignore to ensure DSCResource.Tests folder is commited.
+*   Addition of .gitignore to ensure DSCResource.Tests folder is committed.
 *   Updated AppVeyor.yml to use WMF 5 build environment.
 
 ### 0.1.0.0
 
 *   Initial release with the following resources 
-    *   <span style="font-family:Calibri; font-size:medium">xAdcsCertificationAuthority and xAdcsWebEnrollment.</span> 
+    *   <span style="font-family:Calibri; font-size:medium">xAdcsCertificationAuthority and xAdcsWebEnrollment.</span>
 
 ### Examples
 
@@ -272,8 +277,8 @@ This example will add the Windows Server Roles and Features to support a Certifi
 ```powershell
 Configuration CertificateAuthority
 {
-    Node ‘NodeName’ 
-    {  
+    Node ‘NodeName’
+    {
         WindowsFeature ADCS-Cert-Authority
         {
                Ensure = 'Present'
@@ -284,7 +289,7 @@ Configuration CertificateAuthority
             Ensure = 'Present'
             Credential = $Node.Credential
             CAType = 'EnterpriseRootCA'
-            DependsOn = '[WindowsFeature]ADCS-Cert-Authority'              
+            DependsOn = '[WindowsFeature]ADCS-Cert-Authority'
         }
         WindowsFeature ADCS-Web-Enrollment
         {
@@ -295,7 +300,7 @@ Configuration CertificateAuthority
         xADCSWebEnrollment CertSrv
         {
             Ensure = 'Present'
-            Name = 'CertSrv'
+            IsSingleInstance = 'Yes'
             Credential = $Node.Credential
             DependsOn = '[WindowsFeature]ADCS-Web-Enrollment','[xADCSCertificationAuthority]ADCS'
         }
@@ -303,12 +308,12 @@ Configuration CertificateAuthority
 }
 ```
 
-#### Example 2: Remove the AD CS functionality from a server. 
+#### Example 2: Remove the AD CS functionality from a server
 
 ```powershell
 Configuration RetireCertificateAuthority
 {        
-    Node ‘NodeName’ 
+    Node ‘NodeName’
     {
         xADCSWebEnrollment CertSrv
         {

--- a/Tests/Unit/MSFT_xAdcsWebEnrollment.Tests.ps1
+++ b/Tests/Unit/MSFT_xAdcsWebEnrollment.Tests.ps1
@@ -1,5 +1,5 @@
 $Global:DSCModuleName   = 'xAdcsDeployment'
-$Global:DSCResourceName = 'MSFT_xAdcsOnlineResponder'
+$Global:DSCResourceName = 'MSFT_xAdcsWebEnrollment'
 
 #region HEADER
 # Unit Test Template Version: 1.0
@@ -29,36 +29,37 @@ try
 
         Describe "$($Global:DSCResourceName)\Get-TargetResource" {
 
-            function Install-AdcsOnlineResponder {
-                [CmdletBinding()]
-                param($Credential,[Switch]$Force,[Switch]$WhatIf)
+            function Install-AdcsWebEnrollment {
+                [cmdletbinding()]
+                param($CAConfig,$Credential,[Switch]$Force,[Switch]$WhatIf)
             }
-            function Uninstall-AdcsOnlineResponder {
-                [CmdletBinding()]
+            function Uninstall-AdcsWebEnrollment {
+                [cmdletbinding()]
                 param([Switch]$Force)
             }
 
             #region Mocks
-            Mock Install-AdcsOnlineResponder 
-            Mock Uninstall-AdcsOnlineResponder
+            Mock Install-AdcsWebEnrollment 
+            Mock Uninstall-AdcsWebEnrollment
             #endregion
 
             Context 'comparing Ensure' {
                 $Splat = @{
                     IsSingleInstance = 'Yes'
                     Ensure = 'Present'
+                    CAConfig = 'CA1.contoso.com\contoso-CA1-CA'
                     Credential = $DummyCredential
                 }
                 $Result = Get-TargetResource @Splat
 
                 It 'should return StateOK false' {
                     $Result.Ensure | Should Be $Splat.Ensure
-                    $Result.StateOK | Should Be $False
+                    $Result.IsCAWeb | Should Be $False
                 }
 
                 It 'should call all mocks' {
                     Assert-MockCalled `
-                        -commandName Install-AdcsOnlineResponder `
+                        -commandName Install-AdcsWebEnrollment `
                         -Exactly 1
                 }
             }
@@ -66,34 +67,35 @@ try
 
         Describe "$($Global:DSCResourceName)\Set-TargetResource" {
 
-            function Install-AdcsOnlineResponder {
-                [CmdletBinding()]
-                param($Credential,[Switch]$Force,[Switch]$WhatIf)
+            function Install-AdcsWebEnrollment {
+                [cmdletbinding()]
+                param($CAConfig,$Credential,[Switch]$Force,[Switch]$WhatIf)
             }
-            function Uninstall-AdcsOnlineResponder {
-                [CmdletBinding()]
+            function Uninstall-AdcsWebEnrollment {
+                [cmdletbinding()]
                 param([Switch]$Force)
             }
 
             #region Mocks
-            Mock Install-AdcsOnlineResponder
-            Mock Uninstall-AdcsOnlineResponder
+            Mock Install-AdcsWebEnrollment
+            Mock Uninstall-AdcsWebEnrollment
             #endregion
 
             Context 'testing Ensure Present' {
                 $Splat = @{
                     IsSingleInstance = 'Yes'
                     Ensure = 'Present'
+                    CAConfig = 'CA1.contoso.com\contoso-CA1-CA'
                     Credential = $DummyCredential
                 }
                 Set-TargetResource @Splat
 
                 It 'should call install mock only' {
                     Assert-MockCalled `
-                        -commandName Install-AdcsOnlineResponder `
+                        -commandName Install-AdcsWebEnrollment `
                         -Exactly 1
                     Assert-MockCalled `
-                        -commandName Uninstall-AdcsOnlineResponder `
+                        -commandName Uninstall-AdcsWebEnrollment `
                         -Exactly 0
                 }
             }
@@ -102,16 +104,17 @@ try
                 $Splat = @{
                     IsSingleInstance = 'Yes'
                     Ensure = 'Absent'
+                    CAConfig = 'CA1.contoso.com\contoso-CA1-CA'
                     Credential = $DummyCredential
                 }
                 Set-TargetResource @Splat
 
                 It 'should call uninstall mock only' {
                     Assert-MockCalled `
-                        -commandName Install-AdcsOnlineResponder `
+                        -commandName Install-AdcsWebEnrollment `
                         -Exactly 0
                     Assert-MockCalled `
-                        -commandName Uninstall-AdcsOnlineResponder `
+                        -commandName Uninstall-AdcsWebEnrollment `
                         -Exactly 1
                 }
             }
@@ -119,24 +122,25 @@ try
 
         Describe "$($Global:DSCResourceName)\Test-TargetResource" {
 
-            function Install-AdcsOnlineResponder {
-                [CmdletBinding()]
-                param($Credential,[Switch]$Force,[Switch]$WhatIf)
+            function Install-AdcsWebEnrollment {
+                [cmdletbinding()]
+                param($CAConfig,$Credential,[Switch]$Force,[Switch]$WhatIf)
             }
-            function Uninstall-AdcsOnlineResponder {
-                [CmdletBinding()]
+            function Uninstall-AdcsWebEnrollment {
+                [cmdletbinding()]
                 param([Switch]$Force)
             }
 
             #region Mocks
-            Mock Install-AdcsOnlineResponder
-            Mock Uninstall-AdcsOnlineResponder
+            Mock Install-AdcsWebEnrollment
+            Mock Uninstall-AdcsWebEnrollment
             #endregion
 
             Context 'testing ensure present' {
                 $Splat = @{
                     IsSingleInstance = 'Yes'
                     Ensure = 'Present'
+                    CAConfig = 'CA1.contoso.com\contoso-CA1-CA'
                     Credential = $DummyCredential
                 }
                 $Result = Test-TargetResource @Splat
@@ -146,7 +150,7 @@ try
                 }
                 It 'should call install mock only' {
                     Assert-MockCalled `
-                        -commandName Install-AdcsOnlineResponder `
+                        -commandName Install-AdcsWebEnrollment `
                         -Exactly 1
                 }
             }
@@ -155,6 +159,7 @@ try
                 $Splat = @{
                     IsSingleInstance = 'Yes'
                     Ensure = 'Absent'
+                    CAConfig = 'CA1.contoso.com\contoso-CA1-CA'
                     Credential = $DummyCredential
                 }
                 $Result = Test-TargetResource @Splat
@@ -164,7 +169,7 @@ try
                 }
                 It 'should call install mock only' {
                     Assert-MockCalled `
-                        -commandName Install-AdcsOnlineResponder `
+                        -commandName Install-AdcsWebEnrollment `
                         -Exactly 1
                 }
             }


### PR DESCRIPTION
This also contains the following changes:
```
* MSFT_xAdcsWebEnrollment: Created unit tests based on v1.0 Test Template.
                           Update to meet Style Guidelines and ensure consistency.
                           Updated to IsSingleInstance model. **Breaking change**
* MSFT_xAdcsOnlineResponder: Update Unit tests to use v1.0 Test Template.
                             Unit tests can be run without AD CS installed.
                             Update to meet Style Guidelines and ensure consistency.
```

I updated both MSFT_xAdcsOnlineResponder and MSFT_xAdcsWebEnrollment to match the Style Guidelines as they both had large numbers of violations. I also updated the Tests to match the v1.0 Unit Test templates. The unit tests can now also be run on a Non-Server OS without AD CS installed.

I did not change the MSFT_xAdcsCertificationAuthority resource, but it does still require some work (unit tests, style guidelines violations) to bring it in line. I will work on that at some point, but that will be a separate PR. I may also be able to add Integration tests for these resources as well.

I did not feel comfortable committing the changes to this without resolving the above issues as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xadcsdeployment/12)
<!-- Reviewable:end -->

Also fixes #16