### PR TITLE
Resolved #36

### DIFF
--- a/DSCResources/MSFT_xAdcsCertificationAuthority/MSFT_xAdcsCertificationAuthority.psm1
+++ b/DSCResources/MSFT_xAdcsCertificationAuthority/MSFT_xAdcsCertificationAuthority.psm1
@@ -202,7 +202,8 @@ Function Get-TargetResource
     $null = $adcsParameters.Remove('Debug')
     $null = $adcsParameters.Remove('ErrorAction')
     
-    if($CertFilePassword){
+    if($CertFilePassword)
+    {
         $adcsParameters['CertFilePassword'] = $CertFilePassword.Password
     }
     try
@@ -420,7 +421,8 @@ Function Set-TargetResource
 
     $errorMessage = ''
     
-    if($CertFilePassword){
+    if($CertFilePassword)
+    {
         $adcsParameters['CertFilePassword'] = $CertFilePassword.Password
     }
     switch ($Ensure)
@@ -644,7 +646,8 @@ Function Test-TargetResource
     $null = $adcsParameters.Remove('Debug')
     $null = $adcsParameters.Remove('ErrorAction')
     
-    if($CertFilePassword){
+    if($CertFilePassword)
+    {
         $adcsParameters['CertFilePassword'] = $CertFilePassword.Password
     }
     try

--- a/DSCResources/MSFT_xAdcsCertificationAuthority/MSFT_xAdcsCertificationAuthority.psm1
+++ b/DSCResources/MSFT_xAdcsCertificationAuthority/MSFT_xAdcsCertificationAuthority.psm1
@@ -202,10 +202,11 @@ Function Get-TargetResource
     $null = $adcsParameters.Remove('Debug')
     $null = $adcsParameters.Remove('ErrorAction')
     
-    if($CertFilePassword)
+    if ($CertFilePassword)
     {
         $adcsParameters['CertFilePassword'] = $CertFilePassword.Password
     }
+    
     try
     {
         $null = Install-AdcsCertificationAuthority @adcsParameters -WhatIf
@@ -421,10 +422,11 @@ Function Set-TargetResource
 
     $errorMessage = ''
     
-    if($CertFilePassword)
+    if ($CertFilePassword)
     {
         $adcsParameters['CertFilePassword'] = $CertFilePassword.Password
     }
+    
     switch ($Ensure)
     {
         'Present'
@@ -646,10 +648,11 @@ Function Test-TargetResource
     $null = $adcsParameters.Remove('Debug')
     $null = $adcsParameters.Remove('ErrorAction')
     
-    if($CertFilePassword)
+    if ($CertFilePassword)
     {
         $adcsParameters['CertFilePassword'] = $CertFilePassword.Password
     }
+    
     try
     {
         $null = Install-AdcsCertificationAuthority @adcsParameters -WhatIf

--- a/DSCResources/MSFT_xAdcsCertificationAuthority/MSFT_xAdcsCertificationAuthority.psm1
+++ b/DSCResources/MSFT_xAdcsCertificationAuthority/MSFT_xAdcsCertificationAuthority.psm1
@@ -201,7 +201,10 @@ Function Get-TargetResource
     $null = $adcsParameters.Remove('Ensure')
     $null = $adcsParameters.Remove('Debug')
     $null = $adcsParameters.Remove('ErrorAction')
-
+    
+    if($CertFilePassword){
+        $adcsParameters['CertFilePassword'] = $CertFilePassword.Password
+    }
     try
     {
         $null = Install-AdcsCertificationAuthority @adcsParameters -WhatIf
@@ -416,7 +419,10 @@ Function Set-TargetResource
     $null = $adcsParameters.Remove('ErrorAction')
 
     $errorMessage = ''
-
+    
+    if($CertFilePassword){
+        $adcsParameters['CertFilePassword'] = $CertFilePassword.Password
+    }
     switch ($Ensure)
     {
         'Present'
@@ -637,7 +643,10 @@ Function Test-TargetResource
     $null = $adcsParameters.Remove('Ensure')
     $null = $adcsParameters.Remove('Debug')
     $null = $adcsParameters.Remove('ErrorAction')
-
+    
+    if($CertFilePassword){
+        $adcsParameters['CertFilePassword'] = $CertFilePassword.Password
+    }
     try
     {
         $null = Install-AdcsCertificationAuthority @adcsParameters -WhatIf

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ For more information on Web Enrollment services, see [this article on TechNet](h
 ### Unreleased
 
 ### 1.3.0.0
+
 - xAdcsCertificateAuthority: CertFilePassword invalid type - fixes
   [issue #36](https://github.com/PowerShell/xAdcsDeployment/issues/36)
 - Updated to meet HQRM guidelines - fixes

--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ For more information on Web Enrollment services, see [this article on TechNet](h
 ### Unreleased
 
 ### 1.3.0.0
-
+- xAdcsCertificateAuthority: CertFilePassword invalid type - fixes
+  [issue #36](https://github.com/PowerShell/xAdcsDeployment/issues/36)
 - Updated to meet HQRM guidelines - fixes
   [issue #33](https://github.com/PowerShell/xAdcsDeployment/issues/33).
 - Fixed markdown rule violations in README.MD.


### PR DESCRIPTION
Passing incorrect type PSCredential to parameter CertFilePassword (should be Secure String)

<!--
Thanks for submitting a Pull Request (PR) to this project. Your contribution to this project is greatly appreciated!

Please prefix the PR title with the resource name, i.e. 'xAdcsCertificateAuthority: My short description'
If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: xAdcsCertificateAuthority: My short description'

To aid community reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
Change to [x] for each task in the task list that applies to this PR.
-->
**Pull Request (PR) description**
<!-- Replace this with a description of your pull request -->
Passing incorrect type PSCredential to parameter CertFilePassword (should be Secure String)
**This Pull Request (PR) fixes the following issues:**
<!-- Replace this with the list of issues or n/a. Use format: Fixes #123 -->
Fixes #36

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xadcsdeployment/37)
<!-- Reviewable:end -->
